### PR TITLE
Added dealloc call to super which removes all observers to self

### DIFF
--- a/src/ios/IonicKeyboard.m
+++ b/src/ios/IonicKeyboard.m
@@ -96,6 +96,8 @@
 
     [nc removeObserver:self name:UIKeyboardWillShowNotification object:nil];
     [nc removeObserver:self name:UIKeyboardWillHideNotification object:nil];
+
+    [super dealloc];
 }
 
 /* ------------------------------------------------------------- */


### PR DESCRIPTION
CDVPlugin does some work in its dealloc - https://github.com/apache/cordova-ios/blob/master/CordovaLib/Classes/CDVPlugin.m

If super is not called, I don't think these will get unobserved - https://github.com/apache/cordova-ios/blob/master/CordovaLib/Classes/CDVPlugin.m#L48

Not a Cordova expert yet but let me know if I'm mistaken :)
