### PR TITLE
android keyboard height bug fix, density incorrect

### DIFF
--- a/src/android/IonicKeyboard.java
+++ b/src/android/IonicKeyboard.java
@@ -18,7 +18,7 @@ public class IonicKeyboard extends CordovaPlugin{
         //http://developer.android.com/guide/practices/screens_support.html
         DisplayMetrics dm = new DisplayMetrics();
         cordova.getActivity().getWindowManager().getDefaultDisplay().getMetrics(dm);
-        final float density = (float)(dm.density);
+        float density = metrics.density;
         
         final CordovaWebView appView = webView;
         


### PR DESCRIPTION
In testing with galaxy s2, the keyboard height was not being calculated correctly.  I found out the density was being set to an int.  

From here..
http://stackoverflow.com/questions/3166501/getting-the-screen-density-programmatically-in-android

Density can be .75, 1, 1.5, 2, ect. thus it was being rounded to the nearest integer and causing the incorrect keyboard height.

I switched it to be a float
