### PR TITLE
resolve java.lang.NullPointerException

### DIFF
--- a/src/android/IonicKeyboard.java
+++ b/src/android/IonicKeyboard.java
@@ -71,9 +71,10 @@ public class IonicKeyboard extends CordovaPlugin{
 
                     if (v == null) {
                         callbackContext.error("No current focus");
+                    } else {
+                        inputManager.hideSoftInputFromWindow(v.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
+                        callbackContext.success(); // Thread-safe.
                     }
-                    inputManager.hideSoftInputFromWindow(v.getWindowToken(), InputMethodManager.HIDE_NOT_ALWAYS);
-                    callbackContext.success(); // Thread-safe.
                 }
             });
             return true;


### PR DESCRIPTION
Previous Android logcat output:

E/AndroidRuntime(22977): java.lang.NullPointerException
E/AndroidRuntime(22977): 	at com.ionic.keyboard.IonicKeyboard$2.run(IonicKeyboard.java:75)
E/AndroidRuntime(22977): 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
E/AndroidRuntime(22977): 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
E/AndroidRuntime(22977): 	at java.lang.Thread.run(Thread.java:841)
W/ActivityManager(  766):   Force finishing activity 

