### PR TITLE
Added show method to avoid throwing iOS exception – only logs, does not show

### DIFF
--- a/src/ios/IonicKeyboard.m
+++ b/src/ios/IonicKeyboard.m
@@ -142,7 +142,7 @@
 }
 
 - (void) show:(CDVInvokedUrlCommand*)command {
-    NSLog(@"Showing keyboard not supported in iOS");
+    NSLog(@"Showing keyboard not supported in iOS due to platform limitations.");
 }
 
 /*

--- a/src/ios/IonicKeyboard.m
+++ b/src/ios/IonicKeyboard.m
@@ -141,6 +141,10 @@
     [self.webView endEditing:YES];
 }
 
+- (void) show:(CDVInvokedUrlCommand*)command {
+    NSLog(@"Showing keyboard not supported in iOS");
+}
+
 /*
 - (void) styleDark:(CDVInvokedUrlCommand*)command {
     if (!command.arguments || ![command.arguments count]){


### PR DESCRIPTION
I added this method to avoid having an iOS exception being thrown. As I understand, in order to open the keyboard, a specific view needs to be designated as the application's first responder, e.g. UITextField. This PR only prevents an error from being thrown and provides the information to the developer that this functionality is not supported in iOS, as this is a platform limitation.

Somewhat addresses [this issue](https://github.com/driftyco/ionic-plugins-keyboard/issues/46) but does not solve it.
