### PR TITLE
Avoid Android crashes caused by onDestroy NullpointerExceptions

### DIFF
--- a/src/android/IonicKeyboard.java
+++ b/src/android/IonicKeyboard.java
@@ -129,19 +129,17 @@ public class IonicKeyboard extends CordovaPlugin {
 
     @Override
     public void onDestroy() {
-        String msg = "NullPointerException";
         try {
             rootView.getViewTreeObserver().removeOnGlobalLayoutListener(list);
-        } catch (NullPointerException e) {
+        } catch (Exception e) {
+            String msg = "";
 
-            if (rootView == null)
-                msg = "rootView variable is null";
-            if (rootView.getViewTreeObserver() == null)
-                msg = "rootView.getViewTreeObserver() is null";
-            if (list == null)
-                msg = "list variable is null";
+            if (rootView == null) msg += "rootView variable is null ";
+            if (rootView.getViewTreeObserver() == null) msg += "rootView.getViewTreeObserver() is null ";
+            if (list == null) msg += "list variable is null ";
+            if (msg.isEmpty()) msg = e.getMessage();
 
-            Log.d("IonicKeyboard", msg, e);
+            Log.w("IonicKeyboard", msg, e);
         }
         super.onDestroy();
     }

--- a/src/android/IonicKeyboard.java
+++ b/src/android/IonicKeyboard.java
@@ -128,9 +128,20 @@ public class IonicKeyboard extends CordovaPlugin {
 
     @Override
     public void onDestroy() {
-        if (rootView != null && rootView.getViewTreeObserver() && list != null) {
+        if (rootView != null && rootView.getViewTreeObserver() != null && list != null) {
             rootView.getViewTreeObserver().removeOnGlobalLayoutListener(list);
+        } else {
+            String msg = "NullPointerException";
+            if (rootView == null)
+                msg = "rootView variable is null"
+            else if (rootView.getViewTreeObserver() == null)
+                msg = "rootView.getViewTreeObserver() is null";
+            else if (list == null)
+                msg = "list variable is null";
+
+            Log.d("IonicKeyboard", msg);
         }
+        super.onDestroy();
     }
 
 }

--- a/src/android/IonicKeyboard.java
+++ b/src/android/IonicKeyboard.java
@@ -133,7 +133,7 @@ public class IonicKeyboard extends CordovaPlugin {
         } else {
             String msg = "NullPointerException";
             if (rootView == null)
-                msg = "rootView variable is null"
+                msg = "rootView variable is null";
             else if (rootView.getViewTreeObserver() == null)
                 msg = "rootView.getViewTreeObserver() is null";
             else if (list == null)

--- a/src/android/IonicKeyboard.java
+++ b/src/android/IonicKeyboard.java
@@ -1,5 +1,6 @@
 package io.ionic.keyboard;
 
+import android.util.Log;
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
 import org.apache.cordova.CordovaPlugin;
@@ -128,18 +129,19 @@ public class IonicKeyboard extends CordovaPlugin {
 
     @Override
     public void onDestroy() {
-        if (rootView != null && rootView.getViewTreeObserver() != null && list != null) {
+        String msg = "NullPointerException";
+        try {
             rootView.getViewTreeObserver().removeOnGlobalLayoutListener(list);
-        } else {
-            String msg = "NullPointerException";
+        } catch (NullPointerException e) {
+
             if (rootView == null)
                 msg = "rootView variable is null";
-            else if (rootView.getViewTreeObserver() == null)
+            if (rootView.getViewTreeObserver() == null)
                 msg = "rootView.getViewTreeObserver() is null";
-            else if (list == null)
+            if (list == null)
                 msg = "list variable is null";
 
-            Log.d("IonicKeyboard", msg);
+            Log.d("IonicKeyboard", msg, e);
         }
         super.onDestroy();
     }

--- a/src/android/IonicKeyboard.java
+++ b/src/android/IonicKeyboard.java
@@ -128,7 +128,9 @@ public class IonicKeyboard extends CordovaPlugin {
 
     @Override
     public void onDestroy() {
-        rootView.getViewTreeObserver().removeOnGlobalLayoutListener(list);
+        if (rootView != null && rootView.getViewTreeObserver() && list != null) {
+            rootView.getViewTreeObserver().removeOnGlobalLayoutListener(list);
+        }
     }
 
 }


### PR DESCRIPTION
A NullpointerException in onDestroy() method caused crashes, that was reported in play store. This pull request try to avoid crashes. 